### PR TITLE
Add 'tag' value to toast manager callback arguments

### DIFF
--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -61,7 +61,8 @@ fn main() -> Result<()> {
                     "You clicked on {}{}!",
                     action.arg,
                     action
-                        .value
+                        .values
+                        .get(&action.input_id.unwrap_or_default())
                         .map_or(String::new(), |value| format!(", input = {}", value))
                 );
                 println!("{}", message);

--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -77,9 +77,12 @@ fn main() -> Result<()> {
         })
         .on_dismissed(move |reason| {
             match reason {
-                Ok(DismissalReason::UserCanceled) => println!("UserCanceled"),
-                Ok(DismissalReason::ApplicationHidden) => println!("ApplicationHidden"),
-                Ok(DismissalReason::TimedOut) => println!("TimedOut"),
+                Ok(r) if r.reason == DismissalReason::UserCanceled => println!("UserCanceled"),
+                Ok(r) if r.reason == DismissalReason::ApplicationHidden => {
+                    println!("ApplicationHidden")
+                }
+                Ok(r) if r.reason == DismissalReason::TimedOut => println!("TimedOut"),
+                Ok(r) => println!("Unknown dismissal reason"),
                 Err(e) => eprintln!("Error: {:?}", e),
             }
             dismiss_clone.store(true, Ordering::SeqCst);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,8 @@ pub use content::input::Selection;
 pub use content::text::Text;
 use thiserror::Error;
 
-pub mod manager;
-pub use manager::{ActivatedAction, DismissalReason, ToastManager};
+mod manager;
+pub use manager::{ActivatedAction, DismissalReason, ToastDismissed, ToastFailed, ToastManager};
 
 mod toast;
 pub use toast::{Scenario, Toast, ToastDuration};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use content::input::Selection;
 pub use content::text::Text;
 use thiserror::Error;
 
-mod manager;
+pub mod manager;
 pub use manager::{ActivatedAction, DismissalReason, ToastManager};
 
 mod toast;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -31,7 +31,7 @@ pub struct ActivatedAction {
     /// The values that were passed to the input fields.
     pub values: HashMap<String, String>,
     /// This is only present if the action was associated with an input field.
-    pub input_id: String,
+    pub input_id: Option<String>,
 }
 
 /// Represents the dismissal of a toast notification.
@@ -171,7 +171,7 @@ impl ToastManager {
     where
         F: FnMut(Option<ActivatedAction>) + Send + 'static,
     {
-        let id = input_id.map_or("".to_string(), |s| s.to_string());
+        let id = input_id.map(|s| s.to_string());
         self.on_activated = Some(TypedEventHandler::new(
             move |tn, args: &Option<IInspectable>| {
                 f(Self::get_activated_action(tn, args, id.clone()));
@@ -184,7 +184,7 @@ impl ToastManager {
     fn get_activated_action(
         toast: &Option<ToastNotification>,
         inspect: &Option<IInspectable>,
-        input_id: String,
+        input_id: Option<String>,
     ) -> Option<ActivatedAction> {
         let tag = toast
             .as_ref()

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -16,15 +16,35 @@ use crate::{hs, Result, Toast, WinToastError};
 ///
 /// # Fields
 ///
+/// * `tag`: The toast notification tag.
 /// * `arg`: The argument string that was passed to the action.
 /// * `value`: The string that was passed to the input field.
 #[derive(Debug, Clone)]
 pub struct ActivatedAction {
+    /// The Tag associated with the originating toast.
+    /// This is only present if a tag was explicitly set for the toast notification.
+    pub tag: Option<String>,
     /// The argument string that was passed to the action.
     pub arg: String,
     /// The string that was passed to the input field.
     /// This is only present if the action was associated with an input field.
     pub value: Option<String>,
+}
+
+/// Represents the dismissal of a toast notification.
+/// This is passed to the `on_dismissed` callback.
+///
+/// # Fields
+///
+/// * `tag`: The toast notification tag.
+/// * `reason`: The reason for the toast dismissal.
+#[derive(Debug, Clone)]
+pub struct ToastDismissed {
+    /// The Tag associated with the originating toast.
+    /// This is only present if a tag was explicitly set for the toast notification.
+    pub tag: Option<String>,
+    /// The reason for the toast dismissal.
+    pub reason: DismissalReason,
 }
 
 /// Specifies the reason that a toast notification is no longer being shown
@@ -51,6 +71,22 @@ impl DismissalReason {
             _ => Err(WinToastError::InvalidDismissalReason),
         }
     }
+}
+
+/// Represents an error trying to show a toast notification.
+/// This is passed to the `on_failed` callback.
+///
+/// # Fields
+///
+/// * `tag`: The toast notification tag.
+/// * `error`: The error encountered.
+#[derive(Debug)]
+pub struct ToastFailed {
+    /// The Tag associated with the originating toast.
+    /// This is only present if a tag was explicitly set for the toast notification.
+    pub tag: Option<String>,
+    /// The error encountered.
+    pub error: WinToastError,
 }
 
 /// An interface that provides access to the toast notification manager.
@@ -134,8 +170,8 @@ impl ToastManager {
     {
         let id = input_id.map_or("".to_string(), |s| s.to_string());
         self.on_activated = Some(TypedEventHandler::new(
-            move |_, args: &Option<IInspectable>| {
-                f(Self::get_activated_action(args, id.clone()));
+            move |tn, args: &Option<IInspectable>| {
+                f(Self::get_activated_action(tn, args, id.clone()));
                 Ok(())
             },
         ));
@@ -143,9 +179,15 @@ impl ToastManager {
     }
 
     fn get_activated_action(
+        toast: &Option<ToastNotification>,
         inspect: &Option<IInspectable>,
         input_id: String,
     ) -> Option<ActivatedAction> {
+        let tag = toast
+            .as_ref()
+            .and_then(|t| t.Tag().ok())
+            .map(|s| s.to_string());
+
         let args = inspect
             .as_ref()
             .and_then(|arg| arg.cast::<ToastActivatedEventArgs>().ok());
@@ -165,6 +207,7 @@ impl ToastManager {
             .filter(|s| !s.is_empty());
 
         Some(ActivatedAction {
+            tag,
             arg: button_arg?,
             value: user_input,
         })
@@ -173,47 +216,66 @@ impl ToastManager {
     /// Register a callback for when a toast notification is dismissed.
     pub fn on_dismissed<F>(mut self, f: F) -> Self
     where
-        F: Fn(Result<DismissalReason>) + Send + 'static,
+        F: Fn(Result<ToastDismissed>) + Send + 'static,
     {
         self.on_dismissed = Some(TypedEventHandler::new(
-            move |_, args: &Option<ToastDismissedEventArgs>| {
-                f(Self::get_dismissal_reason(args));
+            move |tn, args: &Option<ToastDismissedEventArgs>| {
+                f(Self::get_dismissal_reason(tn, args));
                 Ok(())
             },
         ));
         self
     }
 
-    fn get_dismissal_reason(args: &Option<ToastDismissedEventArgs>) -> Result<DismissalReason> {
-        let args = args.as_ref().and_then(|arg| arg.Reason().ok());
-        match args {
-            Some(reason) => DismissalReason::from_winrt(reason),
-            None => Err(WinToastError::InvalidDismissalReason),
-        }
+    fn get_dismissal_reason(
+        toast: &Option<ToastNotification>,
+        args: &Option<ToastDismissedEventArgs>,
+    ) -> Result<ToastDismissed> {
+        let tag = toast
+            .as_ref()
+            .and_then(|t| t.Tag().ok())
+            .map(|s| s.to_string());
+
+        let Some(winrt_reason) = args.as_ref().and_then(|arg| arg.Reason().ok()) else {
+            return Err(WinToastError::InvalidDismissalReason);
+        };
+
+        Ok(ToastDismissed {
+            tag,
+            reason: DismissalReason::from_winrt(winrt_reason)?,
+        })
     }
 
     /// Register a callback for when a toast notification fails to display.
     pub fn on_failed<F>(mut self, f: F) -> Self
     where
-        F: Fn(WinToastError) + Send + 'static,
+        F: Fn(ToastFailed) + Send + 'static,
     {
         self.on_failed = Some(TypedEventHandler::new(
-            move |_, args: &Option<ToastFailedEventArgs>| {
-                f(Self::get_failed_error(args));
+            move |tn, args: &Option<ToastFailedEventArgs>| {
+                f(Self::get_failed_error(tn, args));
                 Ok(())
             },
         ));
         self
     }
 
-    fn get_failed_error(args: &Option<ToastFailedEventArgs>) -> WinToastError {
-        let err = args.as_ref().and_then(|e| e.ErrorCode().ok());
-        if let Some(e) = err {
-            if e.is_err() {
-                return WinToastError::Os(e.into());
-            }
-        }
-        WinToastError::Unknown
+    fn get_failed_error(
+        toast: &Option<ToastNotification>,
+        args: &Option<ToastFailedEventArgs>,
+    ) -> ToastFailed {
+        let tag = toast
+            .as_ref()
+            .and_then(|t| t.Tag().ok())
+            .map(|s| s.to_string());
+
+        let error = args
+            .as_ref()
+            .and_then(|e| e.ErrorCode().ok())
+            .filter(|e| e.is_err())
+            .map(|e| WinToastError::Os(e.into()))
+            .unwrap_or(WinToastError::Unknown);
+        ToastFailed { tag, error }
     }
 
     /// Send a toast to Windows for display.

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use windows::{
     core::{IInspectable, Interface, HSTRING},
     Data::Xml::Dom::XmlDocument,
@@ -26,9 +28,10 @@ pub struct ActivatedAction {
     pub tag: Option<String>,
     /// The argument string that was passed to the action.
     pub arg: String,
-    /// The string that was passed to the input field.
+    /// The values that were passed to the input fields.
+    pub values: HashMap<String, String>,
     /// This is only present if the action was associated with an input field.
-    pub value: Option<String>,
+    pub input_id: String,
 }
 
 /// Represents the dismissal of a toast notification.
@@ -198,18 +201,34 @@ impl ToastManager {
             .map(|s| s.to_string())
             .filter(|s| !s.is_empty());
 
-        let user_input = args
+        let user_input: HashMap<String, String> = args
             .and_then(|args| args.UserInput().ok())
-            .and_then(|value_set| value_set.Lookup(&hs(input_id)).ok())
-            .and_then(|args| args.cast::<IReference<HSTRING>>().ok())
-            .and_then(|args| args.Value().ok())
-            .map(|s| s.to_string())
-            .filter(|s| !s.is_empty());
+            .map(|value_set| {
+                value_set
+                    .into_iter()
+                    .filter_map(|pair| {
+                        // Now, process each key-value pair
+                        if let (Ok(key), Ok(value)) = (pair.Key(), pair.Value()) {
+                            if let Ok(value_ref) = value.cast::<IReference<HSTRING>>() {
+                                if let Ok(value_hstring) = value_ref.Value() {
+                                    let value_str = value_hstring.to_string();
+                                    if !value_str.is_empty() {
+                                        return Some((key.to_string(), value_str));
+                                    }
+                                }
+                            }
+                        }
+                        None
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
 
         Some(ActivatedAction {
             tag,
             arg: button_arg?,
-            value: user_input,
+            values: user_input,
+            input_id,
         })
     }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -207,18 +207,14 @@ impl ToastManager {
                 value_set
                     .into_iter()
                     .filter_map(|pair| {
-                        // Now, process each key-value pair
-                        if let (Ok(key), Ok(value)) = (pair.Key(), pair.Value()) {
-                            if let Ok(value_ref) = value.cast::<IReference<HSTRING>>() {
-                                if let Ok(value_hstring) = value_ref.Value() {
-                                    let value_str = value_hstring.to_string();
-                                    if !value_str.is_empty() {
-                                        return Some((key.to_string(), value_str));
-                                    }
-                                }
-                            }
+                        let key = pair.Key().ok()?.to_string();
+                        let value_ref = pair.Value().ok()?.cast::<IReference<HSTRING>>().ok()?;
+                        let value_str = value_ref.Value().ok()?.to_string();
+
+                        if value_str.is_empty() {
+                            return None;
                         }
-                        None
+                        Some((key, value_str))
                     })
                     .collect()
             })


### PR DESCRIPTION
See the motivation for this in https://github.com/AtifChy/winrt-toast-reborn/issues/2 - but basically right now the callbacks/events do not allow the receiving code to know _which_ toast this event is about.

In this PR I'm using the `Tag` field of the toast notifications (defined as optional unique string within a toast `Group`, historically limited to 16 chars but able to store 64 since .. 2017 or so) to allow the calling code to link events to the toasts shown.

For this I

* extended the `on_activated` `ActivatedAction` argument type with an optional `tag` field (easiest/lowest impact change)
* wrapped the argument types of  `on_failed` and `on_dismissed` in a `ToastFailed` and `ToastDismissed` struct respectively that contain the same optional `tag` field and a nested `error` or `reason` field of the original enum type
* (updated the sample to compile against the changes)

Let me know if this is something I could upstream w/ you? I do understand that this would be a breaking change and would likely need a bump in version accordingly